### PR TITLE
fix release CI by adding playwright browser installation step

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -30,6 +30,7 @@ jobs:
         run: |
           cd docs
           pnpm install
+          pnpm exec playwright install --with-deps
 
       - name: Build Site
         run: |


### PR DESCRIPTION
This pull request makes a minor update to the production deployment workflow. The change ensures that Playwright and its dependencies are installed before building the site.

* Added a step to run `pnpm exec playwright install --with-deps` in the `.github/workflows/deploy-production.yaml` workflow to install Playwright and required dependencies.